### PR TITLE
Get defensive about opening files which may not exist.

### DIFF
--- a/lib/client.cfc
+++ b/lib/client.cfc
@@ -98,11 +98,13 @@
 			for (i=1; i LTE arrayLen(exception['TagContext']); i=i+1) {
 				if (exception['TagContext'][i]['TEMPLATE'] NEQ currentTemplate) {
 					fileArray = arrayNew(1);
-					file = fileOpen(exception['TagContext'][i]['TEMPLATE'], "read");
-					while (!fileIsEOF(file)) {
-			            arrayAppend(fileArray, fileReadLine(file));
-			        }
-					fileClose(file);
+					if (fileExists(exception['TagContext'][i]['TEMPLATE'])) {
+						file = fileOpen(exception['TagContext'][i]['TEMPLATE'], "read");
+						while (!fileIsEOF(file)) {
+				            arrayAppend(fileArray, fileReadLine(file));
+				        }
+						fileClose(file);
+					}
 					currentTemplate = exception['TagContext'][i]['TEMPLATE'];
 				}
 
@@ -120,7 +122,7 @@
 				if (exception['TagContext'][i]['LINE']-3 GTE 1) { sentryException['sentry.interfaces.Stacktrace']['frames'][i]['pre_context'][1] = fileArray[exception['TagContext'][i]['LINE']-3]; }
 				if (exception['TagContext'][i]['LINE']-2 GTE 1) { sentryException['sentry.interfaces.Stacktrace']['frames'][i]['pre_context'][1] = fileArray[exception['TagContext'][i]['LINE']-2]; }
 				if (exception['TagContext'][i]['LINE']-1 GTE 1) { sentryException['sentry.interfaces.Stacktrace']['frames'][i]['pre_context'][2] = fileArray[exception['TagContext'][i]['LINE']-1]; }
-				sentryException['sentry.interfaces.Stacktrace']['frames'][i]['context_line'] = fileArray[exception['TagContext'][i]['LINE']];
+				if (arrayLen(fileArray) GTE 1) { sentryException['sentry.interfaces.Stacktrace']['frames'][i]['context_line'] = fileArray[exception['TagContext'][i]['LINE']]; }
 				sentryException['sentry.interfaces.Stacktrace']['frames'][i]['post_context'] = arrayNew(1);
 				if (arrayLen(fileArray) GTE exception['TagContext'][i]['LINE']+1) { sentryException['sentry.interfaces.Stacktrace']['frames'][i]['post_context'][1] = fileArray[exception['TagContext'][i]['LINE']+1]; }
 				if (arrayLen(fileArray) GTE exception['TagContext'][i]['LINE']+2) { sentryException['sentry.interfaces.Stacktrace']['frames'][i]['post_context'][2] = fileArray[exception['TagContext'][i]['LINE']+2]; }
@@ -181,7 +183,7 @@
 				captureStuct[this.customHttpInterface]['application'] = appStruct;
 				captureStuct[this.customHttpInterface]['cgi'] = this.cgiVars;
 			}
-			
+
 			captureStuct['sentry.interfaces.Http'] = structNew();
 			captureStuct['sentry.interfaces.Http']['url'] = 'http://' & this.cgiVars.SERVER_NAME & this.cgiVars.SCRIPT_NAME;
 			captureStuct['sentry.interfaces.Http']['method'] = this.cgiVars.REQUEST_METHOD;


### PR DESCRIPTION
I had an issue with the [MuraSentry](https://github.com/al3x-edge/MuraSentry) plugin, where temp files were not found and thus caused an error with `fileOpen`. So I added a little defensive code via `fileExists` and an `arrayLen` check on `fileArray`, which solves the problem.
